### PR TITLE
Add GPU acceleration documentation and bump version to 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,11 @@ Please visit the [citepro-notebook](http://github.com/ptggenomics/citepro_notebo
 
 ----
 
+# GPU acceleration
+Starting from verison 0.1.2, a portion of the work flow is accelerated with [Rapids-singlecell](https://rapids-singlecell.readthedocs.io/en/latest/) library.
+if you plan to use GPU, please [install rapids-singlecell](https://rapids-singlecell.readthedocs.io/en/latest/Installation.html) prior to importing citepro.
+When importing, Citepro will automatically detect the presense of ```rapids-singlecell``` along with ```cupy``` and ```cuml```.
+
+
 
 This repository is under active development

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,8 @@ CITE-pro is built on the popular and well known python packages in the [scverse]
 
  * [celltypist](https://www.celltypist.org/), an automated cell type annotating tool that use RNA signature to predict the celltypes \(such as T or B cells\). 
 
+ * [rapids-singlecell](https://rapids-singlecell.readthedocs.io/en/latest/Installation.html), CUDA-accelerated scanpy.
+
 The purpose of CITE-pro is to provide a suggestion of using the publicly available libraries in a research-only manner, the user is ultimately responsible of determine the quality of data generated. 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "citepro" 
 
-version = "0.1.1a" 
+version = "0.1.2" 
 
 description = "A CITE-seq util code collection"  
 


### PR DESCRIPTION
## Summary
- Documents GPU acceleration support via rapids-singlecell integration starting from v0.1.2
- Adds rapids-singlecell to the dependency list in docs
- Bumps version from 0.1.1a to 0.1.2

## Test plan
- [ ] Verify README GPU acceleration section renders correctly
- [ ] Verify docs/index.md includes rapids-singlecell in the package list
- [ ] Confirm version 0.1.2 is correct in pyproject.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)